### PR TITLE
tasks/main.yml: ignore errors during LUN assignment if ansible is in check mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -87,5 +87,6 @@
   with_subelements:
     - "{{ iscsi_targets }}"
     - disks
+  ignore_errors: "{{ ansible_check_mode }}"
   notify:
     - save targetcli configuration


### PR DESCRIPTION
ignore errors during LUN assignment if ansible is in check mode aka variable 'ansible_check_mode' is set to 'true'

Errors like the following can be ignored in check mode, as the iSCSI object have not been created:
```
failed: [iscsiserver01] (item=[{'wwn': 'iqn.2020-03.foo.example:iscsiserver01', 'initiators': ['node01', 'node02', 'node03']}, {'path': '/dev/sdd', 'name': 'test3', 'type': 'block'}]) => {"ansible_loop_var": "item", "changed": false, "cmd": "targetcli '/iscsi/iqn.2020-03.foo.example:iscsiserver01/tpg1 status'", "error": "No such path /iscsi/iqn.2020-03.foo.example:iscsiserver01\n", "item": [{"initiators": ["node01", "node02", "node03"], "wwn": "iqn.2020-03.foo.example:iscsiserver01"}, {"name": "test3", "path": "/dev/sdd", "type": "block"}], "msg": "ISCSI object doesn't exists", "output": ""}
```